### PR TITLE
feat: allow running apis as one

### DIFF
--- a/QuoteAPI/quote.py
+++ b/QuoteAPI/quote.py
@@ -1,11 +1,18 @@
-from fastapi import FastAPI
+from pathlib import Path
+from fastapi import FastAPI, APIRouter
 from random import randint
 
-app = FastAPI()
+if __name__ == "__main__":
+    app = FastAPI()
+else:
+    app = APIRouter()
 
 @app.get("/quote")
 async def get_quote():
-    file = open("quotes_all.csv", 'r')
+    # triya - workaround to quotes_all.csv being in possibly different places
+    # __file__ is always in the same place regardless if this is being run on
+    # its own or not, so just take advantage of that
+    file = open(f"{Path(__file__).parent.as_posix()}/quotes_all.csv", 'r')
     random_num = randint(2, 7967)
     data = ""
     while random_num > 0:

--- a/leetcode-api/leetcode.py
+++ b/leetcode-api/leetcode.py
@@ -1,13 +1,20 @@
 import requests
 import uvicorn
 from bs4 import BeautifulSoup as bs
-from typing import Union
-from fastapi import FastAPI
-from leetcode_constants import *
+from fastapi import FastAPI, APIRouter
 
-app = FastAPI()
+# triya note - unique to this project is a problem of relative imports -
+# if we run the file itself, from leetcode_constants import * works,
+# but running it from main.py from the parent directory will not
+# this is just accounting for that
+if __name__ == "__main__":
+    app = FastAPI()
+    from leetcode_constants import *
+else:
+    app = APIRouter(prefix="/lcapi")
+    from .leetcode_constants import *
 
-@app.get("/lcapi/{username}")
+@app.get("/{username}")
 def read_item(username: str):
     return leetcodeScrape(username)
 
@@ -82,4 +89,5 @@ def leetcodeScrape(username: str):
     return user
 
 
-uvicorn.run(app, host="localhost", port=8080)
+if __name__ == "__main__":
+    uvicorn.run(app, host="localhost", port=8080)

--- a/leetcode-api/leetcode.py
+++ b/leetcode-api/leetcode.py
@@ -11,10 +11,10 @@ if __name__ == "__main__":
     app = FastAPI()
     from leetcode_constants import *
 else:
-    app = APIRouter(prefix="/lcapi")
+    app = APIRouter()
     from .leetcode_constants import *
 
-@app.get("/{username}")
+@app.get("/lcapi/{username}")
 def read_item(username: str):
     return leetcodeScrape(username)
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+import importlib
+import importlib.util
+from warnings import warn
+from pathlib import Path
+
+import uvicorn
+from fastapi import APIRouter, FastAPI
+
+# python 3.8 doesn't have this natively :(
+def remove_prefix(text: str, prefix: str):
+    return text[len(prefix) :] if text.startswith(prefix) else text
+
+app = FastAPI()
+
+parent_name = str(Path(__file__).parent.as_posix())
+paths_of_python_files = Path(__file__).parent.glob("*/*.py")
+
+for a_path in paths_of_python_files:
+    actual_path = str(a_path.as_posix())
+
+    # so we have the actual full path of the file now, which is great
+    # but what we want to do is make this a relative path compared to main
+    # what we do is remove the path up to the directory this file is in 
+    # (and remove the / after that too), remove the .py at the end, and make
+    # slashes to periods
+    # for example: UF-API-GROUP/directory/file.py becomes directory.file
+    as_module = remove_prefix(actual_path, parent_name)[1:]
+    as_module = as_module[:-3]
+    as_module = as_module.replace("/", ".")
+    
+    # just in case
+    module_name = importlib.util.resolve_name(as_module, None)
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        warn(f"Could not import module {module_name}: {e}")
+        continue
+
+    possible_router = getattr(module, "app", None)
+    if not isinstance(possible_router, APIRouter):
+        continue
+
+    app.include_router(possible_router)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="localhost", port=8080)

--- a/southwest-gym-api/gym.py
+++ b/southwest-gym-api/gym.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import aiohttp
 from bs4 import BeautifulSoup
-from fastapi import FastAPI
+from fastapi import FastAPI, APIRouter
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.decorator import cache
@@ -36,8 +36,10 @@ class PlaceData(BaseModel):
     last_updated: datetime
 
 
-app = FastAPI()
-
+if __name__ == "__main__":
+    app = FastAPI()
+else:
+    app = APIRouter(prefix="/gymstats")
 
 @app.get("/")
 @cache(expire=60 * 5)
@@ -124,4 +126,5 @@ async def startup():
     FastAPICache.init(InMemoryBackend(), prefix="fastapi-cache")
 
 
-uvicorn.run(app, host="localhost", port=8080)
+if __name__ == "__main__":
+    uvicorn.run(app, host="localhost", port=8080)


### PR DESCRIPTION
This PR allows running every API (so far) as one combined API if a user desires. This simply involves running `main.py`, which will do the work for you.

Adjustments have been made to the other APIs to allow this. Basically, we need them to be `APIRouter`s, not `FastAPI`s, but I didn't want to break using them individually... so I used `if __name__ == "__main__"` to accomplish this. This also allows for adjusting relative imports as needed without breaking anything.