### PR TITLE
fix: various fixes for rotation API

### DIFF
--- a/image-rotation-api/image-rotation.py
+++ b/image-rotation-api/image-rotation.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, UploadFile, Response, APIRouter
 from PIL import Image
 import uvicorn
+import io
 
 
 if __name__ == "__main__":
@@ -24,12 +25,17 @@ async def create_upload_file(file: UploadFile):
     if file.content_type.startswith("image/") is False:
         return {"error": "File is not an image"}
 
+    # create a holder to store image
+    new_image = io.BytesIO()
+
     # rotate image 90 degrees
-    Image.open(file.file).rotate(90).save(file.filename)
+    Image.open(file.file).rotate(90, expand=True).save(
+        new_image, format=file.content_type[6:], optimize=True
+    )
+    new_image.seek(0)
 
     # return image
-    image_bytes = open(file.filename, "rb").read()
-    return Response(content=image_bytes, media_type="image/png")
+    return Response(content=new_image.read(), media_type=file.content_type)
 
 
 if __name__ == "__main__":

--- a/image-rotation-api/image-rotation.py
+++ b/image-rotation-api/image-rotation.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, UploadFile, Response, APIRouter
+from fastapi import FastAPI, UploadFile, APIRouter
+from fastapi.responses import StreamingResponse
 from PIL import Image
 import uvicorn
 import io
@@ -11,11 +12,7 @@ else:
 
 
 # Prompts the user to select their image file
-@app.post(
-    "/rotate-image",
-    responses={200: {"content": {"image/png": {}}}},
-    response_class=Response,
-)
+@app.post("/rotate-image")
 async def create_upload_file(file: UploadFile):
     # error handling if nothing uploaded
     if file.filename == "":
@@ -35,7 +32,7 @@ async def create_upload_file(file: UploadFile):
     new_image.seek(0)
 
     # return image
-    return Response(content=new_image.read(), media_type=file.content_type)
+    return StreamingResponse(content=new_image, media_type=file.content_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This goes in and fixes a lot about the rotation API, including:
- Returning non-PNG files as non-PNGs.
- Not storing the rotated file onto the runner's computer.
- Properly rotate images that aren't square.