### PR TITLE
fix: add slash to calc apis

### DIFF
--- a/calculator-api/calculator.py
+++ b/calculator-api/calculator.py
@@ -14,42 +14,42 @@ class Operands(BaseModel):  # This is the format of the JSON Request for these f
     y: int
 
 
-@app.post("calc/add")
+@app.post("/calc/add")
 async def api_add(operands: Operands):  # Finds the sum of x and y
     return operands.x + operands.y
 
 
-@app.post("calc/sub")
+@app.post("/calc/sub")
 async def api_sub(operands: Operands):  # Finds the difference between x and y
     return operands.x - operands.y
 
 
-@app.post("calc/mul")
+@app.post("/calc/mul")
 async def api_mul(operands: Operands):  # Finds the product of x and y
     return operands.x * operands.y
 
 
-@app.post("calc/div")
+@app.post("/calc/div")
 async def api_div(operands: Operands):  # Finds the quotient of x and y
     return operands.x / operands.y
 
 
-@app.post("calc/mod")
+@app.post("/calc/mod")
 async def api_mod(operands: Operands):  # Finds the remainder of x and y
     return operands.x % operands.y
 
 
-@app.post("calc/pow")
+@app.post("/calc/pow")
 async def api_pow(operands: Operands):  # Finds the power of x and y
     return operands.x**operands.y
 
 
-@app.post("calc/root")
+@app.post("/calc/root")
 async def api_root(operands: Operands):  # Finds the root of x and y
     return operands.x ** (1 / operands.y)
 
 
-@app.post("calc/log")
+@app.post("/calc/log")
 async def api_log(operands: Operands):  # Finds the log of x base y
     return log(operands.x, operands.y)
 


### PR DESCRIPTION
Adds a `/` in front of the calculator APIs to make them function better when running in the combined API mode. FastAPI gets a bit confused without them.

Fixes #42.