### PR TITLE
fix: update README for calculator api

### DIFF
--- a/calculator-api/README.md
+++ b/calculator-api/README.md
@@ -17,12 +17,6 @@ To get a local copy up and running follow these simple example steps.
    ```
 2. Install python packages
    ```sh
-   pip install fastapi[all]
+   pip install -r requirements.txt
    ```
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-## Acknowledgments
-
-* [Webminer Quote Database](https://thewebminer.com/buy-famous-quotes-database)
-
 <p align="right">(<a href="#readme-top">back to top</a>)</p>


### PR DESCRIPTION
1. Python dependencies like `uvicorn` are listed in the `requirements.txt` file, so I made the change to guide users to install dependencies from there
2. The acknowledgements mentioned here are applicable for the quotes API and not for the calculator API